### PR TITLE
Netty fix attempt

### DIFF
--- a/Communication/Packets/Incoming/Misc/ClientVariablesEvent.cs
+++ b/Communication/Packets/Incoming/Misc/ClientVariablesEvent.cs
@@ -6,6 +6,7 @@ namespace Plus.Communication.Packets.Incoming.Misc
     {
         public void Parse(GameClient session, ClientPacket packet)
         {
+            int idkYet = packet.PopInt();
             string gordanPath = packet.PopString();
             string externalVariables = packet.PopString();
         }

--- a/Network/Codec/GameDecoder.cs
+++ b/Network/Codec/GameDecoder.cs
@@ -12,17 +12,25 @@ namespace Plus.Network.Codec
     {
         protected override void Decode(IChannelHandlerContext context, IByteBuffer message, List<object> output)
         {
-            output.Add(message);
 
             if (message.ReadableBytes < 5) return;
 
-            message.ReadInt();
+            int length = message.ReadInt();
+
+            if (message.ReadableBytes < length)
+            {
+                message.ResetReaderIndex();
+                return;
+            }
+
             ClientPacket pkt = new ClientPacket(message);
 
             if (PlusEnvironment.GetGame().GetClientManager().TryGetClient(context.Channel.Id, out GameClient session))
             {
                 PlusEnvironment.GetGame().GetPacketManager().TryExecutePacket(session, pkt);
             }
+
+            output.Add(message);
         }
     }
 }

--- a/Network/Codec/GameDecoder.cs
+++ b/Network/Codec/GameDecoder.cs
@@ -12,6 +12,7 @@ namespace Plus.Network.Codec
     {
         protected override void Decode(IChannelHandlerContext context, IByteBuffer message, List<object> output)
         {
+            message.MarkReaderIndex();
 
             if (message.ReadableBytes < 5) return;
 

--- a/Network/Codec/PolicyDecoder.cs
+++ b/Network/Codec/PolicyDecoder.cs
@@ -16,12 +16,13 @@ namespace Plus.Network.Codec
 
             if (delimiter == '<')
             {
+                input.SkipBytes(input.ReadableBytes); // discard all the bytes in this message
                 string p = "<?xml version=\"1.0\"?>\r\n"
                            + "<!DOCTYPE cross-domain-policy SYSTEM \"/xml/dtds/cross-domain-policy.dtd\">\r\n"
                            + "<cross-domain-policy>\r\n"
                            + "<allow-access-from domain=\"*\" to-ports=\"*\" />\r\n"
                            + "</cross-domain-policy>\0";
-                context.WriteAndFlushAsync(Unpooled.CopiedBuffer(Encoding.Default.GetBytes(p))).Wait();
+                context.WriteAndFlushAsync(Unpooled.CopiedBuffer(Encoding.Default.GetBytes(p))).ContinueWith(delegate { context.CloseAsync(); });
             }
             else
             {


### PR DESCRIPTION
Fixed bug with policy decoding and with large packets which are fragmented. Fixed bug with client variables packet missing an integer.

So for me the client wouldn't even start with the current netty implementation. At first it would get stuck on the policy decoder. I changed some code and it was then stuck on ClientVariablesEvent packet parsing. Added the missing integer and it finally entered client. 

Now, one of the current issues with the current implementation of PlusEmu, without DotNetty, is that it can't handle large packets. This is because the packet is so big that it does not fit in a single frame. Say, for example, that I use the floor editor to create a large map, the packet parser bugs and the client ends up freezing. This is the reason why I added the following code to GameDecoder:

```
            int length = message.ReadInt();

            if (message.ReadableBytes < length)
            {
                message.ResetReaderIndex();
                return;
            }
```

However, I am still getting some packets dropped:
![image](https://user-images.githubusercontent.com/25986048/53188157-607d4880-35ca-11e9-831b-3253cfdcf707.png)

Any advice on frame decoding? I was able to find some documentation for plain old Netty, but couldn't find any for DotNetty.