### PR TITLE
Fix userCount not working on nav

### DIFF
--- a/HabboHotel/Rooms/RoomUserManager.cs
+++ b/HabboHotel/Rooms/RoomUserManager.cs
@@ -464,7 +464,8 @@ namespace Plus.HabboHotel.Rooms
         public void UpdateUserCount(int count)
         {
             userCount = count;
-
+            _room.UsersNow = count;
+            
             using (IQueryAdapter dbClient = PlusEnvironment.GetDatabaseManager().GetQueryReactor())
             {
                 dbClient.RunQuery("UPDATE `rooms` SET `users_now` = '" + count + "' WHERE `id` = '" + _room.RoomId + "' LIMIT 1");


### PR DESCRIPTION
Currently when a user enters a room the user_count on the navigator is not updated. This causes the room to always have '0' users in it.

This fix ensures that the user count is always updated for a room on the navigator